### PR TITLE
Fix detection of git URLs in dependencies

### DIFF
--- a/lib/xpm/install.js
+++ b/lib/xpm/install.js
@@ -1696,7 +1696,13 @@ class Install extends CliCommand {
     const cacheFolderPath = context.globalConfig.cacheFolderPath
 
     let pack
-    if (value.match(/^[a-zA-Z]+:/)) {
+    let url
+    try {
+      url = new URL(value)
+    } catch {
+      url = undefined
+    }
+    if (url) {
       // If an URL, keep it as is.
       pack = value
     } else {


### PR DESCRIPTION
An npm dependency that specifies a git repository as its value can use a URL protocol of the form `git+http://` or `git+https://`. These are not correctly determined to be URLs. A simple fix could be to try to form a url using the `URL` constructor, which should throw an exception if the dependency value is not a URL.