### PR TITLE
Support any git URL

### DIFF
--- a/lib/xpm/install.js
+++ b/lib/xpm/install.js
@@ -81,6 +81,8 @@ const fsPromises = fs.promises
 // arm-none-eabi-g++ cannot find <bits/c++-allocator.h>.
 const useAbsolutePathsWindows = true
 
+const gitLinkRegex = "^.+\.git$"
+
 // ============================================================================
 
 export class Install extends CliCommand {
@@ -863,6 +865,11 @@ export class Install extends CliCommand {
 
     if (manifest._from.match(/^[a-zA-Z]+:/)) {
       // If an URL, keep it as is.
+      return manifest._from
+    }
+
+    if (manifest._from.match(gitLinkRegex)) {
+      // If a git link, keep it as is.
       return manifest._from
     }
 
@@ -1758,9 +1765,14 @@ export class Install extends CliCommand {
       // If an URL, keep it as is.
       pack = dependency.specifier
     } catch (err) {
-      // Not an URL, assume the short syntax `name@version`.
-      const version = dependency.specifier.replace(/^[^0-9]+/, '')
-      pack = `${key}@${version}`
+      if (dependency.specifier.match(gitLinkRegex)) {
+        // Is a git link, keep it as is
+        pack = dependency.specifier
+      } else {
+        // Not an URL, assume the short syntax `name@version`.
+        const version = dependency.specifier.replace(/^[^0-9]+/, '')
+        pack = `${key}@${version}`
+      }
     }
 
     if (isString(dependency.local) &&


### PR DESCRIPTION
Added git link regex test to computeDependencyValue(). Previously, when a non-github ssh link was attempting to be installed
( e.g. git@<domain>:<name>/<repo>.git ), the version string was being stored in package.json instead of the git ssh link. Using
npm, the ssh link would be stored properly.

Added git link regex test to collectDependency if URL throws. I suspect this throws when the git link is to a privately hosted git server instance.

#184 