### PR TITLE
support setting environment variables

### DIFF
--- a/lib/xpm/run-action.js
+++ b/lib/xpm/run-action.js
@@ -315,6 +315,7 @@ export class RunAction extends CliCommand {
 
     let commandsArray
     let configuration
+    let environment
 
     if (configurationName) {
       // --config
@@ -363,6 +364,12 @@ export class RunAction extends CliCommand {
       }
 
       log.trace(`initial action: '${commandsArray}'`)
+
+      // Merge the global and the configuration environment
+      environment = packageJson.xpack.environment || {}
+      Object.assign(environment, configuration.environment || {})
+
+      log.trace(`environment: '${environment}'`)
     } else {
       // Prefer actions defined in the "xpack" property.
       if (packageJson.xpack.actions) {
@@ -380,6 +387,11 @@ export class RunAction extends CliCommand {
           'check "xpack.actions" or "scripts" ')
       }
       log.trace(`script command: '${commandsArray}'`)
+
+      // Get the global environment
+      environment = packageJson.xpack.environment || {}
+
+      log.trace(`environment: '${environment}'`)
     }
 
     if (isString(commandsArray)) {
@@ -393,6 +405,17 @@ export class RunAction extends CliCommand {
       log.trace(util.inspect(err))
       throw new CliError(err.message)
     }
+
+    try {
+      for (const v of Object.keys(environment)) {
+        environment[v] = await liquidEngine.performSubstitutions(
+          environment[v], liquidMap)
+      }
+    } catch (err) {
+      log.trace(util.inspect(err))
+      throw new CliError(err.message)
+    }
+
     const otherArguments = CliOptions.filterOtherArguments(args)
 
     if (commandsArray.length > 1 && otherArguments.length > 0) {
@@ -418,6 +441,8 @@ export class RunAction extends CliCommand {
 
     // Create a copy of the environment.
     const env = Object.assign({}, process.env)
+    // Enrich it with the xpack environment.
+    Object.assign(env, environment)
 
     let pathsArray = []
 

--- a/tests/mock/devdep/package.json
+++ b/tests/mock/devdep/package.json
@@ -36,8 +36,40 @@
         "platforms": "all"
       }
     },
-    "properties": {},
-    "actions": {},
-    "buildConfigurations": {}
+    "properties": {
+      "commandEchoGLOBAL": {
+        "linux": "echo $GLOBAL",
+        "darwin": "echo $GLOBAL",
+        "win32": "echo %GLOBAL%"
+      },
+      "buildFolderRelativePath": "{{ 'build' | path_join: configuration.name | to_filename | downcase }}"
+    },
+    "environment": {
+      "GLOBAL": "VALUE1"
+    },
+    "actions": {
+      "prepare": [
+        "{{ properties.commandEchoGLOBAL[os.platform] }}"
+      ]
+    },
+    "buildConfigurations": {
+      "conf1": {
+        "properties": {
+          "commandEchoCONF": {
+            "linux": "echo $GLOBAL $CONF",
+            "darwin": "echo $GLOBAL $CONF",
+            "win32": "echo %GLOBAL% %CONF%"
+          }
+        },
+        "environment": {
+          "CONF": "VALUE2"
+        },
+        "actions": {
+          "prepare": [
+            "{{ properties.commandEchoCONF[os.platform] }}"
+          ]
+        }
+      }
+    }
   }
 }

--- a/tests/tap/540-xpm-run-action.js
+++ b/tests/tap/540-xpm-run-action.js
@@ -22,13 +22,15 @@
 
 // ----------------------------------------------------------------------------
 
+import * as path from 'path'
+
 // The `[node-tap](http://www.node-tap.org)` framework.
 import { test } from 'tap'
 
 // ----------------------------------------------------------------------------
 
 // ES6: `import { CliExitCodes } from 'cli-start-options'
-// import { CliExitCodes } from '@ilg/cli-start-options';
+// import { CliExitCodes } from '@ilg/cli-start-options'
 import cliStartOptionsCsj from '@ilg/cli-start-options'
 
 // ----------------------------------------------------------------------------
@@ -98,5 +100,63 @@ test('xpm run -h',
     }
     t.end()
   })
+
+/**
+ * Test if environment injection works.
+ */
+test('xpm run prepare',
+  async (t) => {
+    try {
+      const { code, stdout, stderr } = await Common.xpmCli([
+        'run',
+        'prepare',
+        '-q',
+        '-C',
+        path.join('tests', 'mock', 'devdep')
+      ])
+      // Check exit code.
+      t.equal(code, CliExitCodes.SUCCESS, 'exit code is success')
+      const outLines = stdout.split(/\r?\n/)
+      t.ok(outLines.length > 0, 'has enough output')
+      if (outLines.length > 0) {
+        t.match(outLines[0],
+          'VALUE1', 'has global environment variable')
+      }
+      // There should be no error messages.
+      t.equal(stderr, '', 'stderr is empty')
+    } catch (err) {
+      t.fail(err.message)
+    }
+    t.end()
+  })
+
+test('xpm run prepare --config conf1',
+  async (t) => {
+    try {
+      const { code, stdout, stderr } = await Common.xpmCli([
+        'run',
+        'prepare',
+        '-q',
+        '--config',
+        'conf1',
+        '-C',
+        path.join('tests', 'mock', 'devdep')
+      ])
+      // Check exit code.
+      t.equal(code, CliExitCodes.SUCCESS, 'exit code is success')
+      const outLines = stdout.split(/\r?\n/)
+      t.ok(outLines.length > 0, 'has enough output')
+      if (outLines.length > 0) {
+        t.match(outLines[0],
+          'VALUE1 VALUE2', 'has configuration environment variable')
+      }
+      // There should be no error messages.
+      t.equal(stderr, '', 'stderr is empty')
+    } catch (err) {
+      t.fail(err.message)
+    }
+    t.end()
+  })
+
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
This adds support for setting environment variables when running actions

Unlike the commands, which are expanded in a single LiquidJS instance, the variables are expanded in separate instances. This is probably worth discussing.